### PR TITLE
stop false advertising for the mac users

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -3,9 +3,7 @@
 	"version": "v1.4.4-beta.5",
 	"gd": {
 		"win": "2.206",
-		"mac": "2.206",
-		"android": "2.206",
-		"ios": "2.206"
+		"mac": "2.206"
 	},
 	"early-load": true,
 	"id": "thesillydoggo.qolmod",


### PR DESCRIPTION
i removed mac and ios from mod.json since it doesn't build for those - it's appearing on index for mac even though it doesnt have a dylib