### PR TITLE
Fix performance issues

### DIFF
--- a/src/Client/AndroidBall.cpp
+++ b/src/Client/AndroidBall.cpp
@@ -33,7 +33,7 @@ bool AndroidBall::init()
     btn = CCSprite::create("qolmodButtonBG.png"_spr);
     btn->addChildAtPosition(btnOverlay, Anchor::Center);
     menu->addChild(btn);
-    
+
     this->addChild(menu);
     this->setZOrder(69420 - 1);
     this->scheduleUpdate();
@@ -178,14 +178,16 @@ void AndroidBall::UpdateVisible(bool i)
 
     this->setVisible(vis);
 
-    menu->setScale(clampf(Mod::get()->getSavedValue<float>("button-scale", 1), 0.2f, 1));
+    ColourUtility::pastel++;
+    instance = this;
+
+    if (!vis) {
+        return;
+    }
 
     menu->setPosition(position);
 
-    ColourUtility::pastel++;
-
     btnOverlay->setColor(ColourUtility::getPastelColour());
-    instance = this;
 
     if (btn->getActionByTag(69))
         return;
@@ -203,9 +205,10 @@ void AndroidBall::UpdateVisible(bool i)
 
     int op = Mod::get()->getSavedValue<int>("normal-opacity", 255);
 
-    if (PlayLayer::get())
+    if (auto pl = PlayLayer::get())
     {
-        if (CCScene::get()->getChildByType<PauseLayer>(0))
+        // if (CCScene::get()->getChildByType<PauseLayer>(0))
+        if (pl->m_isPaused)
         {
             op = Mod::get()->getSavedValue<int>("normal-opacity", 255);
         }
@@ -247,6 +250,10 @@ void AndroidBall::UpdateVisible(bool i)
     }
 }
 
+void AndroidBall::updateButtonScale(float scale) {
+    menu->setScale(clampf(scale, 0.2f, 1));
+}
+
 AndroidBall::~AndroidBall()
 {
     if (instance == this)
@@ -275,11 +282,11 @@ void AndroidBall::setColonThreeEnabled()
 
     auto spr = CCSprite::create(isColonThreeEnabled() ? "qolmodButtonOverlaycolonthree.png"_spr : "qolmodButtonOverlay.png"_spr)->getTexture();
     btnOverlay->setTexture(spr);
-    
+
 #ifndef GEODE_IS_IOS
     auto over = CCClippingNode::create(btn);
     over->setAlphaThreshold(0.9f);
-    
+
     auto inner = CCLayerColor::create(ccc4(255, 255, 255, 255));
     inner->setAnchorPoint(ccp(0.5f, 0.5f));
     inner->setContentSize(ccp(100, 100));

--- a/src/Client/AndroidBall.h
+++ b/src/Client/AndroidBall.h
@@ -44,6 +44,7 @@ class AndroidBall : public CCLayer
         static float clampf(float v, float min, float max);
 
         void UpdateVisible(bool i);
+        void updateButtonScale(float scale);
 
         bool editorShouldBeVisible();
 

--- a/src/Client/Client.cpp
+++ b/src/Client/Client.cpp
@@ -219,7 +219,7 @@ void Client::sortWindows(bool instant)
     {
         if (!yMap.contains(x))
             yMap[x] = offset;
-        
+
         if (x + window->getDesiredWindowSize().x > ImGui::GetIO().DisplaySize.x)
         {
             x = offset;
@@ -237,7 +237,7 @@ void Client::sortWindows(bool instant)
                 wndPos = ImVec2(x, yMap[x + window->getDesiredWindowSize().x + offset]);
             }
         }
-        
+
         x += window->getDesiredWindowSize().x + offset;
         yMap[x] += window->getDesiredWindowSize().y + offset;
 
@@ -252,7 +252,7 @@ void Client::sortWindows(bool instant)
         {
             if (window->getActionByTag(69))
                 window->stopActionByTag(69);
-            
+
             auto action = CCEaseInOut::create(CCMoveTo::create(instant ? 0 : 0.5f, ccp(wndPos.x, wndPos.y)), 2);
             action->setTag(69);
 
@@ -303,7 +303,7 @@ void Client::toggleWindowVisibility(WindowTransitionType type, bool instant)
                 {
                     window->setPosition(ccp(window->actualWindowPos.x, window->actualWindowPos.y + (!isWindowOpen ? 0 : (ImGui::GetIO().DisplaySize.y + window->getDesiredWindowSize().y) * (verticalUp ? 1 : -1))));
                 }
-                
+
                 verticalMove = CCEaseInOut::create(CCMoveTo::create(instant ? 0 : 0.5f, ccp(window->actualWindowPos.x, window->actualWindowPos.y + (isWindowOpen ? 0 : (ImGui::GetIO().DisplaySize.y + window->getDesiredWindowSize().y) * (verticalUp ? 1 : -1)))), 2);
                 verticalMove->setTag(69);
 
@@ -355,7 +355,7 @@ ccColor4B Client::getThemeColour(std::string key, ccColor4B def)
 {
     if (!ini->hasKey(fmt::format("Colors::{}", key)))
         return def;
-    
+
     auto res = cc4bFromHexString(ini->getKeyValue(fmt::format("Colors::{}", key), ""), false, false);
 
     if (res.isOk())
@@ -438,12 +438,23 @@ void Client::loadImGuiTheme(std::string theme)
     THEME_COLOUR(ModalWindowDimBg);
 }
 
-bool Client::GetModuleEnabled(std::string id)
+bool Client::GetModuleEnabled(std::string_view id)
 {
     if (!mod)
         mod = Mod::get();
 
-    return mod->getSavedValue<bool>(fmt::format("{}_enabled", id));
+    auto hash = std::hash<std::string_view>{}(id);
+    if (enabledModuleCache.contains(hash)) {
+        return enabledModuleCache[hash];
+    }
+
+    bool enabled = mod->getSavedValue<bool>(fmt::format("{}_enabled", id));
+    SetModuleEnabled(id, enabled);
+    return enabled;
+}
+
+void Client::SetModuleEnabled(std::string_view id, bool enabled) {
+    enabledModuleCache[std::hash<std::string_view>{}(id)] = enabled;
 }
 
 Module* Client::GetModule(std::string id)

--- a/src/Client/Client.h
+++ b/src/Client/Client.h
@@ -31,12 +31,13 @@ class Client
 public:
     static inline Client* instance = nullptr;
     static inline Mod* mod = nullptr;
+    static inline std::unordered_map<size_t, bool> enabledModuleCache;
 
     std::vector<Window*> windows;
     static inline CCPoint tileSize = CCPoint(42, 9);
     float animStatus = 0;
     float delta = 0;
-    
+
     bool isWindowOpen = true;
     ccColor4B accentColour = ccc4(207, 67, 115, 255);
 
@@ -53,7 +54,7 @@ public:
     static Client* get();
 
     bool handleKeybinds(enumKeyCodes key, bool isDown, bool isRepeatedKey);
-    
+
     bool useImGuiUI();
     void initImGui();
     void drawImGui();
@@ -70,7 +71,8 @@ public:
     std::vector<std::filesystem::path> getLanguages();
 
     //[[deprecated("GetModuleEnabled has been deprecated due to lag, please rember to cache the module :3")]]
-    static bool GetModuleEnabled(std::string id);
+    static bool GetModuleEnabled(std::string_view id);
+    static void SetModuleEnabled(std::string_view id, bool enabled);
 
     static Module* GetModule(std::string id);
 };

--- a/src/Client/Module.cpp
+++ b/src/Client/Module.cpp
@@ -317,3 +317,15 @@ CCSize Module::sizeForOptionsPage()
     // idk man
     return optionSizeForce == CCSizeZero ? CCSizeMake(350, std::ceil((std::max<int  >(options.size(), 3) - 1) / 2) * 35 + 110) : optionSizeForce;
 }
+
+void Module::save() {
+    Mod::get()->setSavedValue<bool>(id + "_enabled", enabled);
+    keybind.saveToModule(id);
+    Client::SetModuleEnabled(id, enabled);
+}
+
+void Module::load() {
+    keybind = KeyStruct::loadFromModule(id);
+    enabled = Mod::get()->getSavedValue<bool>(id + "_enabled", def);
+    save();
+}

--- a/src/Client/Module.h
+++ b/src/Client/Module.h
@@ -111,25 +111,15 @@ class Module : public UIComponent
                 delegate->onModuleChanged(this->enabled);
         }
 
-        virtual void save()
-        {
-            geode::prelude::Mod::get()->setSavedValue<bool>(id + "_enabled", enabled);
-            keybind.saveToModule(id);
-        }
-
-        virtual void load()
-        {
-            keybind = KeyStruct::loadFromModule(id);
-            enabled = geode::prelude::Mod::get()->getSavedValue<bool>(id + "_enabled", def);
-            save();
-        }
+        virtual void save();
+        virtual void load();
 
         void onInfoAndroid(CCObject* sender);
         void onOptionsAndroid(CCObject* sender);
         void onToggleAndroid(CCObject* sender);
 
         void setIncompatible(std::string str);
-        
+
         virtual void makeAndroid(CCNode* menu, CCPoint pos);
 };
 

--- a/src/Client/Windows/Config.cpp
+++ b/src/Client/Windows/Config.cpp
@@ -121,7 +121,7 @@ void Config::cocosCreate(CCMenu* menu)
     lang->setPosition(lang->getContentSize() / 2);
     lang->setAnchorPoint(CCPointZero);
     lang2->setPosition(lang2->getContentSize() / 2);
-    
+
     auto buttonTab = CCMenu::create();
     buttonTab->setContentWidth(menu->getContentWidth());
     buttonTab->setContentHeight(menu->getContentHeight() - 32);
@@ -340,7 +340,7 @@ void Config::cocosCreate(CCMenu* menu)
     FADE_ICON(41, 11, 70, -1, 1);   // justin
     // FADE_ICON(77, 1, 5, -1, 8);     // baby (ninxout)
     FADE_ICON(335, 98, 41, 15, 19);  // alphalaneous
-    
+
     aboutTab->addChild(iconsMenu);
 
     auto discord = CCMenuItemSpriteExtra::create(CCSprite::createWithSpriteFrameName("gj_discordIcon_001.png"), menu, menu_selector(Config::onLink)); // https://discord.gg/DfQSTEnQKK
@@ -419,7 +419,7 @@ void Config::onChangeTab(CCObject* sender)
         if (sprJoin)
             sprJoin->setVisible(false);
     }
-    
+
     CCArrayExt<CCMenuItemToggler*> tabs = as<CCNode*>(sender)->getParent()->getChildren();
 
     for (auto tab : tabs)
@@ -534,7 +534,7 @@ void Config::createBtn(CCNode* menu, int i)
         spr->addChild(gr);
         sprSel->addChild(gr);
     }
-    
+
     if (i == -2)
     {
         auto gr = CCLabelBMFont::create("Darken", "bigFont.fnt");
@@ -601,13 +601,18 @@ void Config::onSliderChanged(CCObject* sender)
 
     Mod::get()->setSavedValue<int>("editor-opacity", (int)(ved));
 
-    Mod::get()->setSavedValue<float>("button-scale", scale->getThumb()->getValue());
+    float scaleVal = scale->getThumb()->getValue();
+    Mod::get()->setSavedValue<float>("button-scale", scaleVal);
 
-    btnMenu->setScale(AndroidBall::clampf(Mod::get()->getSavedValue<float>("button-scale", 1), 0.2f, 1));
+    if (auto ab = AndroidBall::get()) {
+        ab->updateButtonScale(scaleVal);
+    }
+
+    btnMenu->setScale(AndroidBall::clampf(scaleVal, 0.2f, 1));
 
     btn->stopAllActions();
     btnL->stopAllActions();
-    
+
     btn->runAction(CCFadeTo::create(Client::GetModuleEnabled("instant-fade") ? 0 : 0.35f, Mod::get()->getSavedValue<int>("normal-opacity", 255)));
     btnL->runAction(CCFadeTo::create(Client::GetModuleEnabled("instant-fade") ? 0 : 0.35f, Mod::get()->getSavedValue<int>("normal-opacity", 255)));
 
@@ -672,14 +677,14 @@ void Config::drawImGui()
         if (ImGui::IsMouseClicked(ImGuiMouseButton_Left))
         {
             dragOffset = windowPos;
-        }        
+        }
 
         setPosition(ccp(dragOffset.x + ImGui::GetMouseDragDelta().x, dragOffset.y + ImGui::GetMouseDragDelta().y));
         actualWindowPos = ImVec2(dragOffset.x + ImGui::GetMouseDragDelta().x, dragOffset.y + ImGui::GetMouseDragDelta().y);
     }
 
     float v = ImGuiCocos::get().getUIScale();
-    
+
     if (ImGui::InputFloat("UI Scale", &v, 0.1f, 0.2f))
         Client::get()->setUIScale(v);
 

--- a/src/Hacks/StartposSwitcher.cpp
+++ b/src/Hacks/StartposSwitcher.cpp
@@ -123,7 +123,7 @@ class $modify (StartposPlayLayer, PlayLayer)
 
         m_fields->position = ccp(Mod::get()->getSavedValue<float>("startpos-position.x", CCDirector::get()->getWinSize().width / 2), Mod::get()->getSavedValue<float>("startpos-position.y", 25));
         m_fields->scale = Mod::get()->getSavedValue<float>("startpos-scale", 1);
-        m_fields->opacity = Mod::get()->getSavedValue<float>("startpos-opacity", 75.0f / 255.0f);
+        m_fields->opacity = Mod::get()->getSavedValue<float>("startpos-opacity", 1);
 
         m_fields->label->setString(fmt::format("{}/{}", m_fields->selectedIndex + 1, m_fields->objs.size()).c_str());
         m_fields->label->limitLabelWidth(100, 0.65f, 0);
@@ -131,7 +131,7 @@ class $modify (StartposPlayLayer, PlayLayer)
         auto action = CCSequence::create(CCFadeTo::create(0.1f, 225), CCFadeTo::create(0.6f, 225), CCFadeTo::create(0.3f, 255 * m_fields->opacity), nullptr);
         auto action2 = CCSequence::create(CCFadeTo::create(0.1f, 225), CCFadeTo::create(0.6f, 225), CCFadeTo::create(0.3f, 255 * m_fields->opacity), nullptr);
         auto action3 = CCSequence::create(CCFadeTo::create(0.1f, 225), CCFadeTo::create(0.6f, 225), CCFadeTo::create(0.3f, 255 * m_fields->opacity), nullptr);
-        
+
         m_fields->label->runAction(action);
         m_fields->left->runAction(action2);
         m_fields->right->runAction(action3);
@@ -141,12 +141,10 @@ class $modify (StartposPlayLayer, PlayLayer)
     {
         PlayLayer::postUpdate(dt);
 
-        m_fields->position = ccp(Mod::get()->getSavedValue<float>("startpos-position.x", CCDirector::get()->getWinSize().width / 2), Mod::get()->getSavedValue<float>("startpos-position.y", 25));
-        m_fields->scale = Mod::get()->getSavedValue<float>("startpos-scale", 1);
-        m_fields->opacity = Mod::get()->getSavedValue<float>("startpos-opacity", 1);
+        auto fields = m_fields.self();
 
-        m_fields->menu->setPosition(m_fields->position);
-        m_fields->menu->setScale(m_fields->scale);
+        fields->menu->setPosition(m_fields->position);
+        fields->menu->setScale(m_fields->scale);
     }
 };
 


### PR DESCRIPTION
This PR fixes massive performance issues with the mod, boosting performance by up to 1000%. Currently QOLMod lags a lot, especially on low end devices and in conjunction with mods like Globed. We used a profiler to find the hot paths, and optimized them.

Apologies if there are some things that were accidentally broken - we've tested the mod and didn't find anything that changed, but the codebase is a little confusing so I might've missed something.

Changes:

* Don't update the qolmod button every frame if the button is not visible
* Don't read and set the scale of the button every frame, only when it's changed
* Faster pauselayer check
* Start pos switcher no longer redundantly reads the settings every frame, only once
* `GetModuleEnabled` no longer relies on solely saved values, and instead there is now an enabled module cache, which is a much faster `std::unordered_map`. Every module calls `SetModuleEnabled` when saving/loading, to populate the map. This one was the *biggest* bottleneck by far, and this change makes `GetModuleEnabled` a *very* fast function, unlike what it was before.