### PR TITLE
Ensure level type is saved, and add coin removal

### DIFF
--- a/src/Hacks/Shortcuts/UncompleteLevel.cpp
+++ b/src/Hacks/Shortcuts/UncompleteLevel.cpp
@@ -31,7 +31,7 @@ class UncompleteLevel : public ButtonModule, public FLAlertLayerProtocol
                 }
             }
 
-            if (!level)
+            if (!level || level->m_levelType != GJLevelType::Saved)
             {
                 BetterAlertLayer::createWithLocalisation("ui/title-error", "uncomplete-level/no-level-found", "ui/ok-button")->show();
                 return;
@@ -51,7 +51,7 @@ class UncompleteLevel : public ButtonModule, public FLAlertLayerProtocol
 
         virtual void FLAlert_Clicked(FLAlertLayer* layer, bool btn2)
         {
-            GJGameLevel* level = reinterpret_cast<GJGameLevel*>(layer->getUserData());
+            GJGameLevel* level = static_cast<GJGameLevel*>(layer->getUserData());
 
             if (btn2)
             {
@@ -82,6 +82,19 @@ class UncompleteLevel : public ButtonModule, public FLAlertLayerProtocol
                     GameStatsManager::get()->setStat("5", GameStatsManager::get()->getStat("5") - 1);
                 }
 
+                for (auto i = 0; i < level->m_coins; i++)
+                {
+                    auto key = level->getCoinKey(i + 1);
+                    if (GameStatsManager::get()->hasUserCoin(key) && level->m_coinsVerified.value() > 0)
+                    {
+                        GameStatsManager::get()->setStat("12", GameStatsManager::get()->getStat("12") - 1);
+                        GameStatsManager::get()->m_verifiedUserCoins->removeObjectForKey(key);
+                    }
+                    else if (GameStatsManager::get()->hasPendingUserCoin(key))
+                    {
+                        GameStatsManager::get()->m_pendingUserCoins->removeObjectForKey(key);
+                    }
+                }
 
                 GameLevelManager::get()->saveLevel(level);
             }


### PR DESCRIPTION
This PR adds removing user coins from the users stats. It also adds a check to ensure that the level is a saved level, or else people will get this issue (when attempting to uncomplete an editor level):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/abe348c1-6568-46e9-b51c-0a44d558bbc7" />
They cannot delete Milky Ways, unless they were to manually edit their save files to remove it from the dictionary.

This is also an issue when attempting to uncomplete a main level.
Feel free to change the error message for if the level isn't a saved level.