### PR TITLE
prevent show trajectory crash in level or level editor

### DIFF
--- a/src/Hacks/Level/ShowTrajectory/Hooks.cpp
+++ b/src/Hacks/Level/ShowTrajectory/Hooks.cpp
@@ -58,7 +58,7 @@ class $modify(GJBaseGameLayer)
     {
         bool intersects = false;
 
-        if (obj->m_orientedBox && obj->m_shouldUseOuterOb)
+        if (obj->m_orientedBox && player->m_orientedBox && obj->m_shouldUseOuterOb)
             intersects = obj->m_orientedBox->overlaps(player->m_orientedBox);
         else
             intersects = player->getObjectRect().intersectsRect(obj->getObjectRect());


### PR DESCRIPTION
This fixes a crash that happened when entering certain levels with show trajectory enabled